### PR TITLE
Split reference download and bowtie build in separate processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,46 @@ _NB. Running this pipeline without docker would require modification of module n
 Sample FASTQ files are in the root folder (fastq_files) along with the barcodes per samples (barcode_files). Replace the files inside these 2 folders with your own experimental data in order to run the pipeline on your dataset. 
 
 ```
-nextflow run . -with-docker mazdax/nf-cage:latest
+nextflow run . -with-docker mazdax/nf-cage:latest 
 
 ```
+
+or 
+
+```
+nextflow run -profile docker .
+N E X T F L O W  ~  version 21.04.3
+Launching `./main.nf` [cranky_cantor] - revision: 9e652e725b
+
+===============================================
+        nf-cage BovReg's pipeline
+        github.com/mazdax/nf-cage
+        docker pull mazdax/nf-cage
+===============================================
+Input : Raw Illumina CAGE sequences
+Input : Barcode list TSV (i.e. sample   barcode)
+Input : Reference Genome FASTA (bowtie2 index)
+Output : Strand specific bp resolution bigWig 
+Running task: AIO CAGEfightR import ready
+-----------------------------------------------
+
+executor >  local (103)
+[9b/f36040] process > qc_pre (FastQC...)                      [100%] 2 of 2 ✔
+[f2/a8d4ee] process > demux (Demultiplexing...)               [100%] 2 of 2 ✔
+[53/7323fa] process > merger (Gathering demux...)             [100%] 20 of 20 ✔
+[37/e53393] process > qc_post (FastQC...)                     [100%] 20 of 20 ✔
+[35/4590e7] process > multiqc (MultiQC...)                    [100%] 1 of 1 ✔
+[87/7af88a] process > trimmer (Trimming by TagDust2...)       [100%] 19 of 19 ✔
+[26/c6d571] process > mapKeeper (Sourcing the reference...)   [100%] 1 of 1 ✔
+[0d/b0ce36] process > mapper (Mapping using bowtie2...)       [100%] 19 of 19 ✔
+[c6/e7ddfb] process > bG2bW (BAM >>> bedGraph >>> BigWig ...) [100%] 19 of 19 ✔
+Completed at: 04-Sep-2021 13:42:08
+Duration    : 1d 2h 35m 41s
+CPU hours   : 212.7
+Succeeded   : 103
+
+```
+
 
 # Container and toolset
 This pipeline uses a docker container for all the tools required and the mamba environment. Please find the details at Docker hub public repository https://hub.docker.com/r/mazdax/nf-cage :

--- a/modules/local/process/bedG_to_bigWig.nf
+++ b/modules/local/process/bedG_to_bigWig.nf
@@ -19,7 +19,7 @@ process bG2bW {
         tuple val(name) , path(bam)
     // Use of subsampled fastq files results in bedtools and bG2bW errors that prevents the test run. The optional flag allows the pipeline to finish regardless.
     //Double check the EOF for both bw and bedGraph.gz files to ensure correct analysis. 
-    
+
     output:
         path '*.bedGraph.gz' optional true
         path '*.bw' optional true
@@ -36,7 +36,7 @@ process bG2bW {
         bedtools genomecov -ibam ${bam} -d -strand + | awk -v width=1 '!(\$1~/^NW/)&&(\$3!=0) {print \$1,\$2,\$2+width,\$3}' > ${name}.plus.bedGraph & \
         bedtools genomecov -ibam ${bam} -d -strand - | awk -v width=1 '!(\$1~/^NW/)&&(\$3!=0) {print \$1,\$2,\$2+width,\$3}' > ${name}.minus.bedGraph 
         sort -k 1,1 -k2,2n ${name}.plus.bedGraph > ${name}_tmp_plus
-        sort -k 1,1 -k2,2n ${name}.minus.bedGraph > ${name}_tmp_mins 
+        sort -k 1,1 -k2,2n ${name}.minus.bedGraph > ${name}_tmp_minus 
         bedGraphToBigWig ${name}_tmp_plus /home/ref/ref_cov ${name}.plus.bw && \
         rm -f ${name}_tmp_plus
         bedGraphToBigWig ${name}_tmp_minus /home/ref/ref_cov ${name}.minus.bw && \

--- a/modules/local/process/bedG_to_bigWig.nf
+++ b/modules/local/process/bedG_to_bigWig.nf
@@ -17,9 +17,12 @@ process bG2bW {
 
     input:
         tuple val(name) , path(bam)
+    // Use of subsampled fastq files results in bedtools and bG2bW errors that prevents the test run. The optional flag allows the pipeline to finish regardless.
+    //Double check the EOF for both bw and bedGraph.gz files to ensure correct analysis. 
+    
     output:
-        path '*.bedGraph.gz' , emit: OUT_bedGraph
-        path '*.bw', emit: OUT_bigWig
+        path '*.bedGraph.gz' optional true
+        path '*.bw' optional true
                 
     //In order to use system \$vars as well as DSL $vars
     // The issue is the for loop behaviour which cannot be invoked (process)

--- a/modules/local/process/mapper.nf
+++ b/modules/local/process/mapper.nf
@@ -81,15 +81,15 @@ process mapper {
     
     script:
     """
-        INDEX=`find -L ./ -name "*.rev.1.bt2" | sed 's/.rev.1.bt2//'`
+    INDEX=`find -L ./ -name "*.rev.1.bt2" | sed 's/.rev.1.bt2//'`
 
-        mkdir -p bams && \\
-        bowtie2 -p $params.all_threads --met-file ${name}.metrics --very-sensitive \\
-        --rg-id ${name} --rg LB:${name} --rg PL:ILLUMINA --rg SM:${name} \\
-        -x \$INDEX \\
-        -U ${trimmed_fastq} | \\
-        samtools view -@ $params.all_threads -bS -F 4 | \\
-        samtools sort -@ $params.all_threads -o ${name}.bam
-        samtools index ${name}.bam
+    mkdir -p bams && \\
+    bowtie2 -p $params.all_threads --met-file ${name}.metrics --very-sensitive \\
+    --rg-id ${name} --rg LB:${name} --rg PL:ILLUMINA --rg SM:${name} \\
+    -x \$INDEX \\
+    -U ${trimmed_fastq} | \\
+    samtools view -@ $params.all_threads -bS -F 4 | \\
+    samtools sort -@ $params.all_threads -o ${name}.bam
+    samtools index ${name}.bam
     """
 }


### PR DESCRIPTION
The idea is to separate the reference download process from the bowtie2 build index process. This will avoid mounting the volume with the reference in the docker container, see [here](https://github.com/MazdaX/nf-cage/blob/fa874d7ef0338367027a2004a4fdaf045565cd2a/modules/local/process/mapper.nf#L21) which will make the pipeline less portable since this line won't work when the container technology used is not Docker.